### PR TITLE
OZ-19642: Add HTTP 429 rate limit documentation for Lightroom public APIs

### DIFF
--- a/src/pages/getting-started/developer-guidelines/index.md
+++ b/src/pages/getting-started/developer-guidelines/index.md
@@ -35,6 +35,8 @@ contributors:
 
 - Responses with a 500 may indicate a temporary error condition and should be retried, after backing off. 
 
+- Responses with a 429 indicate too many requests. The response body will be empty. Retry after a brief delay using exponential backoff.
+
 - Retries should be limited - 3  
 
 - See https://status.adobe.com/ for system status 

--- a/src/pages/getting-started/upload-content/index.md
+++ b/src/pages/getting-started/upload-content/index.md
@@ -283,6 +283,8 @@ The Lightroom APIs may return these errors that a shared among all of the entry 
 
 - _Service error_: Calling an API results in an `HTTP 5XX` error. The partner application should retry the request with an exponential timing backoff to give the service time to be restored.
 
+- _Too many requests_: Calling an API results in an `HTTP 429` error. The response body will be empty. The partner application should retry the request after a brief delay using exponential backoff.
+
 ## Error conditions applicable for specific APIs
 
 The Lightroom APIs may return these errors that are specific to the upload APIs:


### PR DESCRIPTION
Document the HTTP 429 (Too Many Requests) error response behavior after CGW migration. Added guidance to developer guidelines and upload content documentation explaining that 429 responses have empty bodies and should be handled with exponential backoff retry.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Updating the developer guidelines with the details for Too many requests - 429 error scenario


## Change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Documentation update for Lightroom public Apis