### PR TITLE
OZ-21565: Document UnexpectedEntitlementError 403 and string/integer error codes

### DIFF
--- a/src/pages/guides/primitive-data-types/index.md
+++ b/src/pages/guides/primitive-data-types/index.md
@@ -9,6 +9,10 @@ contributors:
 
 This page describes data types whose definitions may not be commonly recognized. Unless otherwise stated, these are expressed as strings in the JSON content traversing the Lightroom APIs.
 
+### Error code
+
+When a request fails, the error response body includes a `code` field that identifies the error. This `code` may be returned as **either an integer or a string** depending on the error (for example, `4301` or `"UnexpectedEntitlementError"`). Clients should not assume the `code` is always an integer, and should handle both types when parsing error responses.
+
 ### Lowercase UUID
 
 A [universally-unique identifier](http://en.wikipedia.org/wiki/Universally_unique_identifier) where the hex digits are represented using lower case letters and the hyphens are omitted. Used to identify virtually all objects in the Lightroom cloud.

--- a/static/swagger.json
+++ b/static/swagger.json
@@ -554,7 +554,9 @@
 									"oneOf": [
 										{"$ref": "#/components/schemas/InvalidAPIKeyError"},
 										{"$ref": "#/components/schemas/AccessForbiddenError"},
-										{"$ref": "#/components/schemas/AccessForbiddenAccountStateError"}
+										{"$ref": "#/components/schemas/AccessForbiddenAccountStateError"},
+										{"$ref": "#/components/schemas/UnexpectedEntitlementError"},
+										{"$ref": "#/components/schemas/EntitlementExpiredError"}
 									]
 								},
 								"examples": {
@@ -566,6 +568,12 @@
 									},
 									"AccessForbiddenAccountStateError": {
 										"$ref": "#/components/examples/AccessForbiddenAccountStateExample"
+									},
+									"UnexpectedEntitlementError": {
+										"$ref": "#/components/examples/UnexpectedEntitlementExample"
+									},
+									"EntitlementExpiredError": {
+										"$ref": "#/components/examples/EntitlementExpiredExample"
 									}
 								}
 							}
@@ -4628,6 +4636,28 @@
 					"description": "Access forbidden due to account state of resource owner"
 				}
 			},
+			"UnexpectedEntitlementExample": {
+				"summary": "Unexpected Entitlement (string code)",
+				"value": {
+					"code": "UnexpectedEntitlementError",
+					"description": "Account is in an unexpected status",
+					"errors": {
+						"catalog": [ "not allowed" ]
+					},
+					"subtype": "UnexpectedEntitlementError"
+				}
+			},
+			"EntitlementExpiredExample": {
+				"summary": "Entitlement Expired (string code)",
+				"value": {
+					"code": "EntitlementExpiredError",
+					"description": "Resources unavailable because owner account entitlement has expired",
+					"errors": {
+						"catalog": [ "not allowed" ]
+					},
+					"subtype": "EntitlementExpiredError"
+				}
+			},
 			"OperationNotPermittedExample": {
 				"summary": "Operation Not Permitted",
 				"value": {
@@ -5428,6 +5458,68 @@
 					"description": {
 						"type": "string",
 						"enum": [ "Access forbidden due to account state of resource owner" ]
+					}
+				}
+			},
+			"UnexpectedEntitlementError": {
+				"type": "object",
+				"description": "Returned when the resource owner's account is in an unexpected entitlement state for the requested operation (for example, a partner request on behalf of an account that is not an active subscriber).",
+				"properties": {
+					"code": {
+						"type": "string",
+						"enum": [ "UnexpectedEntitlementError" ],
+						"description": "For this error the code is returned as a string. Note that an error code may be either an integer or a string, so clients should not assume it is always an integer."
+					},
+					"subtype": {
+						"type": "string",
+						"enum": [ "UnexpectedEntitlementError" ]
+					},
+					"description": {
+						"type": "string",
+						"enum": [ "Account is in an unexpected status" ]
+					},
+					"errors": {
+						"type": "object",
+						"properties": {
+							"catalog": {
+								"type": "array",
+								"items": {
+									"type": "string",
+									"enum": [ "not allowed" ]
+								}
+							}
+						}
+					}
+				}
+			},
+			"EntitlementExpiredError": {
+				"type": "object",
+				"description": "Returned when the resource owner's account entitlement has expired (for example, an account whose subscription has lapsed).",
+				"properties": {
+					"code": {
+						"type": "string",
+						"enum": [ "EntitlementExpiredError" ],
+						"description": "For this error the code is returned as a string. Note that an error code may be either an integer or a string, so clients should not assume it is always an integer."
+					},
+					"subtype": {
+						"type": "string",
+						"enum": [ "EntitlementExpiredError" ]
+					},
+					"description": {
+						"type": "string",
+						"enum": [ "Resources unavailable because owner account entitlement has expired" ]
+					},
+					"errors": {
+						"type": "object",
+						"properties": {
+							"catalog": {
+								"type": "array",
+								"items": {
+									"type": "string",
+									"enum": [ "not allowed" ]
+								}
+							}
+						}
 					}
 				}
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Documents previously-undocumented 403 error behavior in the Third Party API reference:

  - Adds an `UnexpectedEntitlementError` error schema (with `code`, `subtype`, `description`, and `errors`) and a matching example, and wires
  it into the `GET /v2/catalog` 403 response (`oneOf` + `examples`).
  - Adds an **Error code** section to the *Primitive Data Types* guide clarifying that an error `code` may be returned as **either an integer 
  or a string** (e.g. `4301` or `"UnexpectedEntitlementError"`), and that clients should handle both types when parsing error responses.

## Related Issue

https://jira.corp.adobe.com/browse/OZ-21565 — *Third Party API Docs don't cover all the 403 error cases*

## Motivation and Context

A third-party developer calling `GET /v2/catalog` received a 403 response whose `code` field was the string `"UnexpectedEntitlementError"`,
  while the docs only ever describe integer codes — leading them to believe the API was behaving incorrectly.

  This was confirmed to be expected behavior: for accounts in a non-subscriber/`created` entitlement state, the self-catalog call can fail
  with `UnexpectedEntitlementError`, and Oz error `code` values have been allowed to be strings as well as integers for a long time. The docs
  simply never captured this. These changes close that documentation gap so partners can correctly parse and handle the response.

  (Note: the separate engineering investigation into the error itself is tracked in OZ-21564; this PR is documentation-only.)

## How Has This Been Tested?

 - Validated `static/swagger.json` is well-formed JSON after the changes (`python3 -m json.tool` / `json.load`).
  - Verified the new `UnexpectedEntitlementError` schema, example, and `oneOf`/`examples` references resolve correctly within the spec.
  - Reviewed the rendered Markdown of the updated *Primitive Data Types* guide section.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
